### PR TITLE
Fix wireframe edge color logic

### DIFF
--- a/demo_collision_detection.py
+++ b/demo_collision_detection.py
@@ -3287,7 +3287,11 @@ class FullPipelineViewer(DualViewer):
             if key in edge_colour_dict:
                 colours_arr[i] = edge_colour_dict[key]
             else:
-                tri_mask = _np.any(_np.isin(tris_np, e), axis=1)
+                # Identify triangles that contain BOTH vertices of the edge (true owners)
+                # A triangle owns the edge iff exactly two of its vertices match the edge's vertices.
+                # Using sum(..., axis=1) avoids expensive Python-level loops while ensuring we only
+                # pick triangles that truly share the complete edge, not just a single vertex.
+                tri_mask = (_np.isin(tris_np, e).sum(axis=1) >= 2)
                 if _np.any(tri_mask):
                     tri_idx = int(_np.argmax(tri_mask))
                     if tri_idx < len(tri_to_mnt):


### PR DESCRIPTION
Correct wireframe edge color assignment in `_compute_wireframe_colors`.

The previous logic `_np.any(_np.isin(tris_np, e), axis=1)` incorrectly identified triangles sharing *any* vertex with an edge, rather than those containing *both*. This resulted in edges being colored by triangles that did not truly own them. The fix ensures that only triangles containing both vertices of an edge are used for color assignment.

---

**Open Background Agent:** 
[Web](https://www.cursor.com/agents?id=bc-fb63347d-dab5-404f-bbe9-77a643d2df20) · [Cursor](https://cursor.com/background-agent?bcId=bc-fb63347d-dab5-404f-bbe9-77a643d2df20)

Learn more about [Background Agents](https://docs.cursor.com/background-agent/web-and-mobile)